### PR TITLE
Change not logged exception when the user doesn't have rigths over nodes

### DIFF
--- a/src/niweb/apps/noclook/schema/core.py
+++ b/src/niweb/apps/noclook/schema/core.py
@@ -536,8 +536,6 @@ class NIObjectType(DjangoObjectType):
                             ret = NodeHandle.objects.filter(node_type=node_type).get(handle_id=int_id)
                         except ValueError:
                             ret = NodeHandle.objects.filter(node_type=node_type).get(handle_id=handle_id)
-                    else:
-                        raise GraphQLAuthException()
                 else:
                     raise GraphQLError('A handle_id must be provided')
 
@@ -572,8 +570,6 @@ class NIObjectType(DjangoObjectType):
 
                     # the node list is trimmed to the nodes that the user can read
                     qs = sriutils.trim_readable_queryset(qs, info.context.user)
-                else:
-                    raise GraphQLAuthException()
             else:
                 raise GraphQLAuthException()
 
@@ -603,8 +599,6 @@ class NIObjectType(DjangoObjectType):
 
                     # the node list is trimmed to the nodes that the user can read
                     qs = sriutils.trim_readable_queryset(qs, info.context.user)
-                else:
-                    raise GraphQLAuthException()
             else:
                 raise GraphQLAuthException()
 
@@ -774,8 +768,6 @@ class NIObjectType(DjangoObjectType):
                     ret = []
 
                 return ret
-            else:
-                raise GraphQLAuthException()
 
         return generic_list_resolver
 


### PR DESCRIPTION
This slight tweak changes the response the graphql api gives when the user requests a list or a node that doesn't have the rights to read. Now instead of raising an error like the user was not logged in, the response is an empty set or a null object.