### PR TITLE
Bugfix: relationship_parent_of field was not using relay id for update

### DIFF
--- a/src/niweb/apps/noclook/schema/mutations.py
+++ b/src/niweb/apps/noclook/schema/mutations.py
@@ -18,6 +18,8 @@ from graphene import Field
 from graphene_django.forms.mutation import DjangoModelFormMutation, BaseDjangoFormMutation
 from django.core.exceptions import ObjectDoesNotExist
 
+from binascii import Error as BinasciiError
+
 from .core import NIMutationFactory, CreateNIMutation, CommentType
 from .types import *
 
@@ -216,10 +218,21 @@ class CreateOrganization(CreateNIMutation):
 
             for field, roledict in DEFAULT_ROLES.items():
                 if field in post_data:
-                    contact_id = post_data.get(field)
-                    contact_id = relay.Node.from_global_id(contact_id)[1]
+                    handle_id = post_data.get(field)
+                    handle_id = relay.Node.from_global_id(handle_id)[1]
                     post_data.pop(field)
-                    post_data.update({field: contact_id})
+                    post_data.update({field: handle_id})
+
+            relay_extra_ids = ('relationship_parent_of', 'relationship_uses_a')
+            for field in relay_extra_ids:
+                handle_id = post_data.get(field)
+                if handle_id:
+                    try:
+                        handle_id = relay.Node.from_global_id(handle_id)[1]
+                        post_data.pop(field)
+                        post_data.update({field: handle_id})
+                    except BinasciiError:
+                        pass # the id is already in handle_id format
 
             form = form_class(post_data)
             form.strict_validation = True
@@ -330,10 +343,18 @@ class UpdateOrganization(UpdateNIMutation):
             # replace relay ids for handle_id in contacts if present
             for field, roledict in DEFAULT_ROLES.items():
                 if field in post_data:
-                    contact_id = post_data.get(field)
-                    contact_id = relay.Node.from_global_id(contact_id)[1]
+                    handle_id = post_data.get(field)
+                    handle_id = relay.Node.from_global_id(handle_id)[1]
                     post_data.pop(field)
-                    post_data.update({field: contact_id})
+                    post_data.update({field: handle_id})
+
+            relay_extra_ids = ('relationship_parent_of', 'relationship_uses_a')
+            for field in relay_extra_ids:
+                handle_id = post_data.get(field)
+                if handle_id:
+                    handle_id = relay.Node.from_global_id(handle_id)[1]
+                    post_data.pop(field)
+                    post_data.update({field: handle_id})
 
             form = form_class(post_data)
             form.strict_validation = True
@@ -368,10 +389,10 @@ class UpdateOrganization(UpdateNIMutation):
 
                 # Set child organizations
                 if form.cleaned_data['relationship_parent_of']:
-                    organization_nh = NodeHandle.objects.get(pk=form.cleaned_data['relationship_parent_of'])
+                    organization_nh = NodeHandle.objects.get(handle_id=form.cleaned_data['relationship_parent_of'])
                     helpers.set_parent_of(request.user, organization, organization_nh.handle_id)
                 if form.cleaned_data['relationship_uses_a']:
-                    procedure_nh = NodeHandle.objects.get(pk=form.cleaned_data['relationship_uses_a'])
+                    procedure_nh = NodeHandle.objects.get(handle_id=form.cleaned_data['relationship_uses_a'])
                     helpers.set_uses_a(request.user, organization, procedure_nh.handle_id)
 
                 return has_error, { graphql_type.__name__.lower(): nh }

--- a/src/niweb/apps/noclook/tests/schema/test_complex.py
+++ b/src/niweb/apps/noclook/tests/schema/test_complex.py
@@ -747,6 +747,8 @@ class OrganizationComplexTest(Neo4jGraphQLTest):
         org_addr_pcode3 = "41001"
         org_addr_parea3 = "Sevilla"
 
+        parent_org_id = relay.Node.to_global_id('Organization', str(self.organization2.handle_id))
+
         nondefault_role = Role.objects.all().first()
         nondefault_roleid = relay.Node.to_global_id("Role", nondefault_role.handle_id)
 
@@ -760,6 +762,7 @@ class OrganizationComplexTest(Neo4jGraphQLTest):
               affiliation_site_owner: false
               affiliation_partner: true
               organization_id: "{org_id}"
+              relationship_parent_of: "{parent_org_id}"
               website: "{org_web}"
               organization_number: "{org_num}"
             }}
@@ -981,8 +984,8 @@ class OrganizationComplexTest(Neo4jGraphQLTest):
           }}
         }}
         '''.format(org_id=organization_id, org_name=org_name,
-                    org_type=org_type, org_web=org_web,
-                    org_num=org_num, c3_first_name=c3_first_name,
+                    org_type=org_type, parent_org_id=parent_org_id,
+                    org_web=org_web, org_num=org_num, c3_first_name=c3_first_name,
                     c3_last_name=c3_last_name, contact_type=contact_type,
                     c3_email=c3_email, email_type=email_type, c3_phone=c3_phone,
                     phone_type=phone_type, nondefault_roleid=nondefault_roleid,


### PR DESCRIPTION
As the organization mutation is not using mutation factories, this field wasn't translated to the handle_id that the backend form validation is expecting.