### PR TITLE
Fix: An empty connection is returned if the user doesn't have rights

### DIFF
--- a/src/niweb/apps/noclook/schema/core.py
+++ b/src/niweb/apps/noclook/schema/core.py
@@ -764,10 +764,10 @@ class NIObjectType(DjangoObjectType):
 
                     ret = list(qs)
 
-                if not ret:
-                    ret = []
+            if not ret:
+                ret = []
 
-                return ret
+            return ret
 
         return generic_list_resolver
 


### PR DESCRIPTION
Minimal fix, an indentation error prevented the code to return an empty connection if the user doesn't have rights to see a list, which was triggering a backend error.