### PR TITLE
Hotfix: Type creation fixed

### DIFF
--- a/src/niweb/apps/noclook/management/commands/csvimport.py
+++ b/src/niweb/apps/noclook/management/commands/csvimport.py
@@ -325,9 +325,17 @@ class Command(BaseCommand):
             raise Exception('Work/Personal values are not available for the \
                                 Email/phone dropdown types')
 
-        contact_type = NodeType.objects.get_or_create(type='Contact', slug='contact')[0] # contact
-        email_type = NodeType.objects.get_or_create(type='Email', slug='email', hidden=True)[0] # contact
-        phone_type = NodeType.objects.get_or_create(type='Phone', slug='phone', hidden=True)[0] # contact
+        contact_type = NodeType.objects.get_or_create(type='Contact', slug='contact')[0]
+
+        # set hidden types
+        email_type = NodeType.objects.get_or_create(type='Email', slug='email')[0]
+        email_type.hidden = True
+        email_type.save()
+
+        phone_type = NodeType.objects.get_or_create(type='Phone', slug='phone')[0]
+        phone_type.hidden = True
+        phone_type.save()
+
         all_contacts = NodeHandle.objects.filter(node_type=contact_type)
 
         for contact in all_contacts:
@@ -365,7 +373,11 @@ class Command(BaseCommand):
 
     def fix_organizations_address(self):
         self.user = get_user()
-        address_type = NodeType.objects.get_or_create(type='Address', slug='address', hidden=True)[0] # address
+        address_type = NodeType.objects.get_or_create(type='Address', slug='address')[0] # address
+        # set it to hidden
+        address_type.hidden=True
+        address_type.save()
+
         organization_type = NodeType.objects.get_or_create(type='Organization', slug='organization')[0] # organization
         all_organizations = NodeHandle.objects.filter(node_type=organization_type)
         logical_meta_type = 'Logical'


### PR DESCRIPTION
As que Graphql Query object builds the api, and builds some of the aux types for contacts and organizations, the csvimport management command was fixed to reflect this as it crashed on the tests.