### PR TITLE
Hotfix: Empty value for mandatory fields resolvers

### DIFF
--- a/src/niweb/apps/noclook/schema/fields.py
+++ b/src/niweb/apps/noclook/schema/fields.py
@@ -59,6 +59,10 @@ class NIBasicField():
         self.manual_resolver = manual_resolver
         self.type_kwargs     = type_kwargs
 
+    def get_default_value(self):
+        # this will trigger a exception for fields that don't define this method
+        return None
+
     def get_resolver(self, **kwargs):
         field_name = kwargs.get('field_name')
         if not field_name:
@@ -69,7 +73,12 @@ class NIBasicField():
             )
         def resolve_node_value(instance, info, **kwargs):
             node = self.get_inner_node(instance)
-            return node.data.get(field_name)
+            value = node.data.get(field_name)
+
+            if not value and self.type_kwargs.get('required', False):
+                value = self.get_default_value()
+
+            return value
 
         return resolve_node_value
 
@@ -86,7 +95,8 @@ class NIStringField(NIBasicField):
     '''
     String type
     '''
-    pass
+    def get_default_value(self):
+        return ''
 
 class NIIntField(NIBasicField):
     '''
@@ -97,6 +107,9 @@ class NIIntField(NIBasicField):
         super(NIIntField, self).__init__(field_type, manual_resolver,
                         type_kwargs, **kwargs)
 
+    def get_default_value(self):
+        return -1
+
 
 class NIBooleanField(NIBasicField):
     '''
@@ -106,6 +119,9 @@ class NIBooleanField(NIBasicField):
                     type_kwargs=None, **kwargs):
         super(NIBooleanField, self).__init__(field_type, manual_resolver,
                         type_kwargs, **kwargs)
+
+    def get_default_value(self):
+        return False
 
     def get_resolver(self, **kwargs):
         field_name = kwargs.get('field_name')

--- a/src/niweb/apps/noclook/schema/fields.py
+++ b/src/niweb/apps/noclook/schema/fields.py
@@ -74,8 +74,12 @@ class NIBasicField():
         def resolve_node_value(instance, info, **kwargs):
             node = self.get_inner_node(instance)
             value = node.data.get(field_name)
+            is_required = False
 
-            if not value and self.type_kwargs.get('required', False):
+            if self.type_kwargs and self.type_kwargs.get('required', False):
+                is_required = True
+
+            if value == None and is_required:
                 value = self.get_default_value()
 
             return value
@@ -134,7 +138,7 @@ class NIBooleanField(NIBasicField):
         def resolve_node_value(instance, info, **kwargs):
             possible_value = self.get_inner_node(instance).data.get(field_name)
             if possible_value == None:
-                possible_value = False
+                possible_value = self.get_default_value()
 
             return possible_value
 
@@ -187,6 +191,9 @@ class NIListField(NIBasicField):
         self.rel_name        = rel_name
         self.rel_method      = rel_method
         self.not_null_list   = not_null_list
+
+    def get_default_value(self):
+        return []
 
     def get_resolver(self, **kwargs):
         rel_name   = kwargs.get('rel_name')

--- a/src/niweb/apps/noclook/tests/schema/community/test_schema.py
+++ b/src/niweb/apps/noclook/tests/schema/community/test_schema.py
@@ -1578,3 +1578,37 @@ class CheckExistentOrganizationIdTest(Neo4jGraphQLCommunityTest):
                                             pformat(result.data, indent=1),
                                             pformat(expected, indent=1)
                                         )
+
+
+class EmptyCommunityDataTest(Neo4jGraphQLCommunityTest):
+    def test_contact_empty_first_name(self):
+        # remove first_name from contact1
+        c1_node = self.contact1.get_node()
+        c1_node.remove_property('first_name')
+
+        contact_1_id = relay.Node.to_global_id(str(self.contact1.node_type),
+                                            str(self.contact1.handle_id))
+
+        # do a simple contact query and check that there's no errors
+        query = """
+        {{
+          getContactById(id: "{contact_1_id}"){{
+            id
+            first_name
+          }}
+        }}
+        """.format(contact_1_id=contact_1_id)
+        result = schema.execute(query, context=self.context)
+        assert not result.errors, pformat(result.errors, indent=1)
+
+        expected = {
+            'getContactById': {
+                'id': contact_1_id,
+                'first_name': '',
+            }
+        }
+
+        assert result.data == expected, '{} \n != {}'.format(
+                                            pformat(result.data, indent=1),
+                                            pformat(expected, indent=1)
+                                        )


### PR DESCRIPTION
As we've checked in the test environment, there may be Contacts where the first_name may not be a present property in the neo4j data.

We've decided that we will resolve to a default value so it doesn't breaks with this field being mandatory in both NOCLook and the graphql api. This solution is also applied already in NOCLook.

If this data triggers validation warnings in the frontend when the user wants to save it, it is ok.