### PR TITLE
Metatype list

### DIFF
--- a/src/niweb/apps/noclook/schema/metatypes.py
+++ b/src/niweb/apps/noclook/schema/metatypes.py
@@ -66,6 +66,13 @@ class Location(NINode):
     has = graphene.Field(lambda:Physical)
 
 
+class MetaType(graphene.Enum):
+    Logical = 'Logical'
+    Relation = 'Relation'
+    Physical = 'Physical'
+    Location = 'Location'
+
+
 ## metatype resolver mixins
 class ResolverUtils:
     @staticmethod

--- a/src/niweb/apps/noclook/schema/types/common.py
+++ b/src/niweb/apps/noclook/schema/types/common.py
@@ -19,3 +19,10 @@ class Dropdown(DjangoObjectType):
 class Neo4jChoice(graphene.ObjectType):
     class Meta:
         interfaces = (KeyValue, )
+
+
+class TypeInfo(graphene.ObjectType):
+    type_name = graphene.String(required=True)
+    connection_name = graphene.String(required=True)
+    byid_name = graphene.String(required=True)
+    all_name = graphene.String(required=True)

--- a/src/niweb/apps/noclook/tests/schema/test_metatypes.py
+++ b/src/niweb/apps/noclook/tests/schema/test_metatypes.py
@@ -187,3 +187,53 @@ class Neo4jGraphQLPhysicalTest(Neo4jGraphQLMetatypeTest):
 
 class Neo4jGraphQLLocationTest(Neo4jGraphQLMetatypeTest):
     pass
+
+
+class MetaTypesQueriesTest(Neo4jGraphQLGenericTest):
+    def test_metatype_list(self):
+        ## simple metatype query
+        query = '''
+        {
+          getMetatypes
+        }
+        '''
+
+        expected = {
+            "getMetatypes": [
+                "Logical",
+                "Relation",
+                "Physical",
+                "Location"
+            ]
+        }
+
+        result = schema.execute(query, context=self.context)
+        assert not result.errors, result.errors
+
+        self.assertEqual(result.data, expected)
+
+
+    def test_metatype_classes(self):
+        ## get types for metatype
+
+        query_t = '''
+        {{
+          getTypesForMetatype(metatype: {metatype_name}){{
+            type_name
+            connection_name
+            byid_name
+            all_name
+          }}
+        }}
+        '''
+
+        qlogical = query_t.format(metatype_name='Logical')
+        qrelation = query_t.format(metatype_name='Relation')
+        qphysical = query_t.format(metatype_name='Physical')
+        qlocation = query_t.format(metatype_name='Location')
+
+        queries = [qlogical, qrelation, qphysical, qlocation]
+
+        for query in queries:
+            result = schema.execute(query, context=self.context)
+            assert not result.errors, result.errors


### PR DESCRIPTION
For the type preselection combo present for the Parent field embed table we needed a graphql query to retrieve all the types that implements a certain metatype.
In this case, this combo placed on the left of the search field, that is on the left of the "Add new" button, and queries for Physical types (Ports, Cables, Switches, etc...).

It adds the following queries (with example inputs):

```
{
  getMetatypes
}

{
  "data": {
    "getMetatypes": [
      "Logical",
      "Relation",
      "Physical",
      "Location" 
    ]
  }
}
```

```
{
  getTypesForMetatype(metatype: Physical){
    type_name
    connection_name
    byid_name
    all_name
  }
}

{
  "data": {
    "getTypesForMetatype": [
      {
        "type_name": "Port",
        "connection_name": "ports",
        "byid_name": "getPortById",
        "all_name": "all_ports" 
      },
      {
        "type_name": "Cable",
        "connection_name": "cables",
        "byid_name": "getCableById",
        "all_name": "all_cables" 
      },
      {
        "type_name": "Router",
        "connection_name": "routers",
        "byid_name": "getRouterById",
        "all_name": "all_routers" 
      }
    ]
  }
}
```
