### PR TITLE
Neo4j user permission query filter for graphql connections

### DIFF
--- a/src/niweb/apps/noclook/tests/schema/community/__init__.py
+++ b/src/niweb/apps/noclook/tests/schema/community/__init__.py
@@ -25,8 +25,16 @@ class Neo4jGraphQLCommunityTest(Neo4jGraphQLGenericTest):
         self.role2 = Role(name='role2').save()
 
         # add nodes to the appropiate context
-        NodeHandleContext(nodehandle=self.organization1, context=self.community_ctxt).save()
-        NodeHandleContext(nodehandle=self.organization2, context=self.community_ctxt).save()
+        self.perm_rel_org1 = \
+            NodeHandleContext(nodehandle=self.organization1, \
+                context=self.community_ctxt)
+        self.perm_rel_org1.save()
+
+        self.perm_rel_org2 = \
+            NodeHandleContext(nodehandle=self.organization2, \
+                context=self.community_ctxt)
+        self.perm_rel_org2.save()
+
         NodeHandleContext(nodehandle=self.contact1, context=self.community_ctxt).save()
         NodeHandleContext(nodehandle=self.contact2, context=self.community_ctxt).save()
         NodeHandleContext(nodehandle=self.group1, context=self.community_ctxt).save()

--- a/src/niweb/apps/noclook/tests/schema/community/test_connections.py
+++ b/src/niweb/apps/noclook/tests/schema/community/test_connections.py
@@ -331,8 +331,6 @@ class OrganizationConnectionTest(Neo4jGraphQLCommunityTest):
             NodeHandleContext.objects.get_or_create(nodehandle=self.organization2, \
                 context=self.community_ctxt)[0]
 
-        print(self.perm_rel_org2)
-
     def test_organizations_filter(self):
         # filter by name
         query = '''


### PR DESCRIPTION
These changes filter the results returned by a graphql connection, to only show what the logged user is allowed to see.

In earlier stages of the project this was tried on the django/postgresql layer but this was proven to be really slow, but with this filter previously developed for the genearl search query results is much faster.