### PR TITLE
Added non privileged way to query groups

### DIFF
--- a/src/niweb/apps/noclook/schema/query.py
+++ b/src/niweb/apps/noclook/schema/query.py
@@ -189,6 +189,30 @@ class NOCRootQuery(NOCAutoQuery):
     # network organizations
     getNetworkOrgTypes = graphene.List(TypeInfo)
 
+    # safe get groups for select combos
+    getPlainGroups = graphene.List(PlainGroup)
+
+    def resolve_getPlainGroups(self, info, **kwargs):
+        if info.context and info.context.user.is_authenticated:
+            ret = []
+            #import pdb; pdb.set_trace()
+
+            group_type_str = 'Group'
+            group_type, created = NodeType.objects.get_or_create(
+                type=group_type_str, slug=group_type_str.lower())
+
+            groups = NodeHandle.objects.filter(node_type=group_type)
+
+            for group in groups:
+                id = relay.Node.to_global_id(group_type_str, str(group.handle_id))
+                name = group.node_name
+
+                ret.append(PlainGroup(id=id, name=name))
+
+            return ret
+        else:
+            raise GraphQLAuthException()
+
     def resolve_getAvailableDropdowns(self, info, **kwargs):
         if info.context and info.context.user.is_authenticated:
             django_dropdowns = [d.name for d in DropdownModel.objects.all()]

--- a/src/niweb/apps/noclook/schema/types/community.py
+++ b/src/niweb/apps/noclook/schema/types/community.py
@@ -197,6 +197,14 @@ class RoleOrderBy(graphene.Enum):
     handle_id_DESC='handle_id_DESC'
 
 
+class PlainGroup(graphene.ObjectType):
+    id = graphene.ID(required=True)
+    name = graphene.String()
+
+    class Meta:
+        interfaces = (relay.Node, )
+
+
 community_type_resolver = {
     'Group' : Group,
     'Procedure' : Procedure,

--- a/src/niweb/apps/noclook/schema/types/network.py
+++ b/src/niweb/apps/noclook/schema/types/network.py
@@ -143,8 +143,11 @@ class Switch(NIObjectType, PhysicalMixin):
     description = NIStringField()
     operational_state = NIStringField(type_kwargs={ 'required': True })
     ip_addresses = NIIPAddrField()
-    responsible_group = NISingleRelationField(field_type=(lambda: Group), rel_name="Takes_responsibility", rel_method="_incoming")
-    support_group = NISingleRelationField(field_type=(lambda: Group), rel_name="Supports", rel_method="_incoming")
+    responsible_group = NISingleRelationField(field_type=(lambda: Group),
+        rel_name="Takes_responsibility", rel_method="_incoming",
+        check_permissions=False)
+    support_group = NISingleRelationField(field_type=(lambda: Group),
+        rel_name="Supports", rel_method="_incoming", check_permissions=False)
     managed_by = NIChoiceField(dropdown_name="host_management_sw")
     backup = NIStringField()
     os = NIStringField()
@@ -152,7 +155,8 @@ class Switch(NIObjectType, PhysicalMixin):
     contract_number = NIStringField()
     rack_units = NIIntField() # Equipment height
     rack_position = NIIntField()
-    provider = NISingleRelationField(field_type=(lambda: Provider), rel_name="Provides", rel_method="_incoming")
+    provider = NISingleRelationField(field_type=(lambda: Provider),
+        rel_name="Provides", rel_method="_incoming")
     max_number_of_ports = NIIntField()
 
     class NIMetaType:
@@ -166,8 +170,12 @@ class Firewall(NIObjectType, PhysicalMixin):
     description = NIStringField()
     operational_state = NIStringField(type_kwargs={ 'required': True })
     ip_addresses = NIIPAddrField()
-    responsible_group = NISingleRelationField(field_type=(lambda: Group), rel_name="Takes_responsibility", rel_method="_incoming")
-    support_group = NISingleRelationField(field_type=(lambda: Group), rel_name="Supports", rel_method="_incoming")
+    responsible_group = NISingleRelationField(field_type=(lambda: Group),
+        rel_name="Takes_responsibility", rel_method="_incoming",
+        check_permissions=False)
+    support_group = NISingleRelationField(field_type=(lambda: Group),
+        rel_name="Supports", rel_method="_incoming", check_permissions=False)
+    managed_by = NIChoiceField(dropdown_name="host_management_sw")
     managed_by = NIChoiceField(dropdown_name="host_management_sw")
     backup = NIStringField()
     security_class = NIChoiceField(dropdown_name="security_classes")


### PR DESCRIPTION
As we've changed how support/responsible group is informed in the database for some of the types present like Host or Firewall, we realized that not all users might have read access to the community data.

Instead we can provide a plain query to get these groups' names and ids to be able to perform form edit operations over those host related entities.