### PR TITLE
"View site" link override

### DIFF
--- a/src/niweb/niweb/admin.py
+++ b/src/niweb/niweb/admin.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+__author__ = 'ffuentes'
+
+from django.contrib import admin
+
+
+class SRIAdminSite(admin.AdminSite):
+    site_url = '/dashboard'

--- a/src/niweb/niweb/apps.py
+++ b/src/niweb/niweb/apps.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+__author__ = 'ffuentes'
+
+from django.contrib.admin.apps import AdminConfig
+
+
+class SRIAdminConfig(AdminConfig):
+    default_site = 'niweb.admin.SRIAdminSite'

--- a/src/niweb/niweb/settings/common.py
+++ b/src/niweb/niweb/settings/common.py
@@ -238,8 +238,6 @@ DJANGO_APPS = (
     'django.contrib.flatpages',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    # Admin panel and documentation:
-    'django.contrib.admin',
 )
 
 THIRD_PARTY_APPS = (
@@ -255,6 +253,8 @@ THIRD_PARTY_APPS = (
 )
 
 LOCAL_APPS = (
+    # Admin panel and documentation (overrided site_url):
+    'niweb.apps.SRIAdminConfig',
     'apps.userprofile',
     'apps.noclook',
     'apps.scan',


### PR DESCRIPTION
A new admin config class and a new admin site was created to change the "View site" link on the django admin. It should now point to SRI's dashboard.