### PR TITLE
Service dates: Set to null

### DIFF
--- a/src/niweb/apps/noclook/forms/common.py
+++ b/src/niweb/apps/noclook/forms/common.py
@@ -860,9 +860,14 @@ class EditServiceForm(forms.Form):
         #TODO: Handle when service type does not exist?
         service_type_ = ServiceType.objects.get(name=cleaned_data.get('service_type'))
         cleaned_data['service_class'] = service_type_.service_class.name
+
         # Check that project_end_date is filled in for Project service type
         if cleaned_data['service_type'] == 'Project' and not cleaned_data['project_end_date']:
             self.add_error('project_end_date', 'Missing project end date.')
+
+        if cleaned_data['service_type'] != 'Project':
+            cleaned_data['project_end_date'] = None
+
         if cleaned_data.get('operational_state', None):
             # Check that decommissioned_date is filled in for operational state Decommissioned
             if cleaned_data['operational_state'] == 'Decommissioned':

--- a/src/niweb/apps/noclook/helpers.py
+++ b/src/niweb/apps/noclook/helpers.py
@@ -110,7 +110,8 @@ def get_provider_id(provider_name):
     return provider_id
 
 
-def form_update_node(user, handle_id, form, property_keys=None):
+def form_update_node(user, handle_id, form, property_keys=None, \
+    nullable_keys=[]):
     """
     Take a node, a form and the property keys that should be used to fill the
     node if the property keys are omitted the form.base_fields will be used.
@@ -138,7 +139,9 @@ def form_update_node(user, handle_id, form, property_keys=None):
                 if key == 'name':
                     nh.node_name = form.cleaned_data[key]
                 activitylog.update_node_property(user, nh, key, pre_value, form.cleaned_data[key])
-        elif form.cleaned_data.get(key, None) == '' and key in node.data.keys():
+        elif form.cleaned_data.get(key, None) == '' and key in node.data.keys()
+                or (form.cleaned_data.get(key, None) == None \
+                    and key in node.data.keys() and key in nullable_keys):
             if key != 'name':  # Never delete name
                 pre_value = node.data.get(key, '')
                 del node.data[key]

--- a/src/niweb/apps/noclook/helpers.py
+++ b/src/niweb/apps/noclook/helpers.py
@@ -139,7 +139,7 @@ def form_update_node(user, handle_id, form, property_keys=None, \
                 if key == 'name':
                     nh.node_name = form.cleaned_data[key]
                 activitylog.update_node_property(user, nh, key, pre_value, form.cleaned_data[key])
-        elif form.cleaned_data.get(key, None) == '' and key in node.data.keys()
+        elif form.cleaned_data.get(key, None) == '' and key in node.data.keys()\
                 or (form.cleaned_data.get(key, None) == None \
                     and key in node.data.keys() and key in nullable_keys):
             if key != 'name':  # Never delete name

--- a/src/niweb/apps/noclook/schema/core.py
+++ b/src/niweb/apps/noclook/schema/core.py
@@ -2532,6 +2532,7 @@ class NIMutationFactory():
         update_include  = getattr(ni_metaclass, 'update_include', None)
         update_exclude  = getattr(ni_metaclass, 'update_exclude', None)
         property_update = getattr(ni_metaclass, 'property_update', None)
+        nullable_keys   = getattr(ni_metaclass, 'nullable_keys', [])
         relay_extra_ids = getattr(ni_metaclass, 'relay_extra_ids', None)
         unique_node     = getattr(ni_metaclass, 'unique_node', False)
 
@@ -2585,6 +2586,7 @@ class NIMutationFactory():
             'include': create_include,
             'exclude': create_exclude,
             'property_update': property_update,
+            'nullable_keys': nullable_keys,
             'relay_extra_ids': relay_extra_ids,
         }
 
@@ -2638,6 +2640,7 @@ class NIMutationFactory():
         del attr_dict['include']
         del attr_dict['exclude']
         del attr_dict['property_update']
+        del attr_dict['nullable_keys']
         del attr_dict['relay_extra_ids']
         attr_dict['is_delete'] = True
 

--- a/src/niweb/apps/noclook/schema/core.py
+++ b/src/niweb/apps/noclook/schema/core.py
@@ -1775,6 +1775,7 @@ class UpdateNIMutation(AbstractNIMutation):
         nimetaclass     = getattr(cls, 'NIMetaClass')
         graphql_type    = getattr(nimetaclass, 'graphql_type')
         property_update = getattr(nimetaclass, 'property_update', None)
+        nullable_keys   = getattr(nimetaclass, 'nullable_keys', [])
         relay_extra_ids = getattr(nimetaclass, 'relay_extra_ids', None)
 
         nimetatype      = getattr(graphql_type, 'NIMetaType')
@@ -1807,7 +1808,8 @@ class UpdateNIMutation(AbstractNIMutation):
             form = form_class(post_data)
             if form.is_valid():
                 # Generic node update
-                helpers.form_update_node(request.user, nodehandler.handle_id, form, property_update)
+                helpers.form_update_node(request.user, nodehandler.handle_id, \
+                    form, property_update, nullable_keys)
 
                 # process relations if implemented
                 cls.process_relations(request, form, nodehandler)

--- a/src/niweb/apps/noclook/schema/mutations/network.py
+++ b/src/niweb/apps/noclook/schema/mutations/network.py
@@ -651,6 +651,7 @@ class NIServiceMutationFactory(NIMutationFactory):
             'responsible_group': responsible_relation_processor,
             'support_group': supports_relation_processor,
         }
+        nullable_keys = ['decommissioned_date', 'project_end_date']
 
     class Meta:
         abstract = False

--- a/src/niweb/apps/noclook/tests/stressload/data_generator.py
+++ b/src/niweb/apps/noclook/tests/stressload/data_generator.py
@@ -1090,6 +1090,9 @@ class NetworkFakeDataGenerator(FakeDataGenerator):
 
         return rack
 
+    def get_random_date(self):
+        return self.fake.date_time_this_year().isoformat().split('T')[0]
+
     def create_service(self, name=None):
         # import services class / types if necesary
         if not ServiceType.objects.all():
@@ -1164,12 +1167,10 @@ class NetworkFakeDataGenerator(FakeDataGenerator):
         }
 
         if service_type_name == "Project":
-            data['project_end_date'] = self.fake.date_time_this_year()\
-                                        .isoformat().split('T')[0]
+            data['project_end_date'] = self.get_random_date()
 
         if data['operational_state'] == "Decommissioned":
-            data['decommissioned_date'] = self.fake.date_time_this_year()\
-                                            .isoformat().split('T')[0]
+            data['decommissioned_date'] = self.get_random_date()
 
         for key, value in data.items():
             if value:


### PR DESCRIPTION
- More deterministic Service test
- Decommissioned date and Project end date could be set to null if the user edits the Operational state (other than "decommissioned") or the Service type (other than "Project")
- Added nullable_keys optional list for form_update_node helper function