### PR TITLE
Router dependents

### DIFF
--- a/src/niweb/apps/noclook/schema/core.py
+++ b/src/niweb/apps/noclook/schema/core.py
@@ -503,10 +503,17 @@ class NIObjectType(DjangoObjectType):
         return cls.create_mutation
 
     @classmethod
-    def set_create_mutation(cls, create_mutation):
+    def can_create(cls):
         can_create = cls.get_from_nimetatype("can_create")
         if can_create == None:
             can_create = True
+
+        return can_create
+
+    @classmethod
+    def set_create_mutation(cls, create_mutation):
+        can_create = cls.can_create()
+
         if can_create:
             cls.create_mutation = create_mutation
         else:

--- a/src/niweb/apps/noclook/schema/core.py
+++ b/src/niweb/apps/noclook/schema/core.py
@@ -481,7 +481,7 @@ class NIObjectType(DjangoObjectType):
     @classmethod
     def get_from_nimetatype(cls, attr):
         ni_metatype = getattr(cls, 'NIMetaType', None)
-        return getattr(ni_metatype, attr)
+        return getattr(ni_metatype, attr, None)
 
     @classmethod
     def get_type_name(cls):
@@ -504,7 +504,13 @@ class NIObjectType(DjangoObjectType):
 
     @classmethod
     def set_create_mutation(cls, create_mutation):
-        cls.create_mutation = create_mutation
+        can_create = cls.get_from_nimetatype("can_create")
+        if can_create == None:
+            can_create = True
+        if can_create:
+            cls.create_mutation = create_mutation
+        else:
+            cls.create_mutation = None
 
     @classmethod
     def get_update_mutation(cls):

--- a/src/niweb/apps/noclook/schema/query.py
+++ b/src/niweb/apps/noclook/schema/query.py
@@ -213,6 +213,9 @@ optical_path_dependency_types = [
                                     OpticalNode, Router, Switch, OpticalPath,
                                     Service,
                                 ]
+router_dependents_types = [
+    Service, OpticalPath, OpticalMultiplexSection, OpticalLink
+]
 
 
 class NOCRootQuery(NOCAutoQuery):
@@ -265,6 +268,10 @@ class NOCRootQuery(NOCAutoQuery):
     # optical_path_dependency_types
     getOpticalPathDependencyTypes = graphene.List(TypeInfo,
             resolver=get_typelist_resolver(optical_path_dependency_types))
+
+    # router_dependents_types
+    getRouterDependentsTypes = graphene.List(TypeInfo,
+            resolver=get_typelist_resolver(router_dependents_types))
 
     # service types
     getServiceTypes = graphene.List(ServiceType, \

--- a/src/niweb/apps/noclook/schema/query.py
+++ b/src/niweb/apps/noclook/schema/query.py
@@ -190,11 +190,14 @@ def get_typelist_resolver(class_list):
                     all_name = NOCRootQuery.\
                         graph_all_type_resolvers[clazz]['field_name']
 
+                    can_create = clazz.can_create()
+
                     elem = TypeInfo(
                         type_name=clazz,
                         connection_name=connection_name,
                         byid_name=byid_name,
                         all_name=all_name,
+                        can_create=can_create,
                     )
 
                     classes.append(elem)

--- a/src/niweb/apps/noclook/schema/types/common.py
+++ b/src/niweb/apps/noclook/schema/types/common.py
@@ -35,6 +35,7 @@ class TypeInfo(graphene.ObjectType):
     connection_name = graphene.String(required=True)
     byid_name = graphene.String(required=True)
     all_name = graphene.String(required=True)
+    can_create = graphene.Boolean()
 
 
 class Action(DjangoObjectType):

--- a/src/niweb/apps/noclook/schema/types/network.py
+++ b/src/niweb/apps/noclook/schema/types/network.py
@@ -87,6 +87,7 @@ class Unit(NIObjectType, LogicalMixin):
         ni_type = 'Unit'
         ni_metatype = NIMETA_LOGICAL
         context_method = sriutils.get_network_context
+        can_create = False
 
 
 class Port(NIObjectType, PhysicalMixin):
@@ -199,6 +200,7 @@ class Router(NIObjectType, PhysicalMixin):
         ni_type = 'Router'
         ni_metatype = NIMETA_PHYSICAL
         context_method = sriutils.get_network_context
+        can_create = False
 
 
 class SwitchType(DjangoObjectType):
@@ -286,6 +288,7 @@ class Firewall(NIObjectType, PhysicalMixin):
         ni_type = 'Firewall'
         ni_metatype = NIMETA_PHYSICAL
         context_method = sriutils.get_network_context
+        can_create = False
 
 
 class ExternalEquipment(NIObjectType, PhysicalMixin):
@@ -519,6 +522,7 @@ class PeeringGroup(NIObjectType, LogicalMixin):
         ni_type = 'Peering Group'
         ni_metatype = NIMETA_LOGICAL
         context_method = sriutils.get_network_context
+        can_create = False
 
 
 # Service


### PR DESCRIPTION
Added query to get the dependents types for Router. Also added can_create flag on type (equivalent but independent from has_creation composite mutation flag) to set explicitly we can't create these entities by themselves.