### PR TITLE
Added name generation testing to service creation and bugfixed

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -17,6 +17,7 @@ graphene-django>=2.0
 django-cors-headers
 vakt
 django-vakt
+pyjwt<1.7.1
 django-graphql-jwt
 Pillow
 Faker

--- a/src/niweb/apps/noclook/schema/mutations/network.py
+++ b/src/niweb/apps/noclook/schema/mutations/network.py
@@ -644,7 +644,7 @@ class NIRackMutationFactory(NIMutationFactory):
 ## Service
 class NIServiceMutationFactory(NIMutationFactory):
     class NIMetaClass:
-        form = EditServiceForm
+        form = SRIServiceForm
         graphql_type = Service
         unique_node = True
         relations_processors = {


### PR DESCRIPTION
The problem was that the name generation for Service occurs in the NewServiceForm, but in order to use all the fields on the create mutation the relied on the EditServiceForm (and this form unlike other edit forms didn't inherited the previous form), a third form was added to provide the cleaning method of both forms.